### PR TITLE
Switch to non-root user from the very start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,12 @@ RUN set -ex \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS \
     && rm -rf /var/lib/apt/lists/*
 
+# Create user, since running as root is insecure:
+RUN useradd --create-home --home-dir /code appuser
+USER appuser
+
 # Copy your application code to the container (make sure you create a .dockerignore file if any large files or directories should be excluded)
-RUN mkdir /code/
-WORKDIR /code/
+WORKDIR /code
 ADD . /code/
 
 # uWSGI will listen on this port
@@ -55,7 +58,7 @@ RUN DATABASE_URL='' /venv/bin/python manage.py collectstatic --noinput
 ENV UWSGI_WSGI_FILE=my_project/wsgi.py
 
 # Base uWSGI configuration (you shouldn't need to change these):
-ENV UWSGI_VIRTUALENV=/venv UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_HTTP_AUTO_CHUNKED=1 UWSGI_HTTP_KEEPALIVE=1 UWSGI_UID=1000 UWSGI_GID=2000 UWSGI_LAZY_APPS=1 UWSGI_WSGI_ENV_BEHAVIOR=holy
+ENV UWSGI_VIRTUALENV=/venv UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_HTTP_AUTO_CHUNKED=1 UWSGI_HTTP_KEEPALIVE=1 UWSGI_LAZY_APPS=1 UWSGI_WSGI_ENV_BEHAVIOR=holy
 
 # Number of uWSGI workers and threads per worker (customize as needed):
 ENV UWSGI_WORKERS=2 UWSGI_THREADS=4

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN useradd --create-home --home-dir /code appuser
 USER appuser
 
 # Copy your application code to the container (make sure you create a .dockerignore file if any large files or directories should be excluded)
-WORKDIR /code
+WORKDIR /code/
 ADD . /code/
 
 # uWSGI will listen on this port


### PR DESCRIPTION
Currently your Dockerfile relies on `uwsgi` to switch to a non-root user. Unfortunately, this makes the image less secure than it could be, since it still starts as root. As I write about here (https://pythonspeed.com/articles/root-capabilities-docker-security/) starting as root opens you up to security attacks, e.g. root-on-host escalation attack in Februrary 2019 that would be prevented by starting out as non-root user.

The PR therefore changes the Dockerfile to run as a non-root user from the very start.

Other suggestions:

* If your CI builds rely on caching to speed things up, another security requirement your tutorial doesn't mention, but perhaps you already do, is rebuilding images from scratch once a week or so, to ensure layer caching doesn't leave you with insecure Debian packages (https://pythonspeed.com/articles/docker-cache-insecure-images/).
* Setting `ENV PYTHONFAULTHANDLER=1` will enable tracebacks on segfaults using https://docs.python.org/3/library/faulthandler.html. Doesn't do much, until the day it saves you hours of staring at the screen wondering what went wrong.

(And if you ever get tired of maintaining your own Docker packaging template, and want one that's even more automated, you might be interested in [licensing the one I've built](https://pythonspeed.com/products/pythoncontainer/). Not Django-specific, but could create a custom version.)
